### PR TITLE
Fix json.Marshal in Entity type (#225)

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -40,7 +40,7 @@ type Entity struct {
 	// Name is the name of the resource or array element.
 	Name string `json:"Name"`
 	// Client is the REST client interface to the system.
-	Client Client
+	Client Client `json:"-"`
 }
 
 // SetClient sets the API client connection to use for accessing this


### PR DESCRIPTION
If you attempt to marshall a gofish object back to JSON, the marshal process errors because some of the object's properties are not set up to be marshalled.

This adds an explicit instruction to the marshalling to not try to include the client.